### PR TITLE
Ensure render-all workflow creates missing labels before PR creation

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -121,9 +121,19 @@ jobs:
             exit 0
           fi
 
+          LABEL_ARGS=()
+          for LABEL in ci metrics; do
+            if gh label view "$LABEL" -R "$REPO" >/dev/null 2>&1 || \
+               gh label create "$LABEL" -R "$REPO" --description "Infrastructure automation" >/dev/null 2>&1; then
+              LABEL_ARGS+=("--label" "$LABEL")
+            else
+              echo "Warning: unable to ensure label '$LABEL' on $REPO, skipping" >&2
+            fi
+          done
+
           gh pr create -R "$REPO" \
             --head "$HEAD" \
             --base "$BASE" \
             --title "chore(metrics): refresh" \
             --body  "Auto-generated metrics update" \
-            --label "ci" --label "metrics"
+            "${LABEL_ARGS[@]}"


### PR DESCRIPTION
## Summary
- ensure the render-all workflow checks for required labels before creating PRs
- create the labels when missing and skip labeling if creation fails

## Testing
- not run (workflow execution requires external GitHub access)


------
https://chatgpt.com/codex/tasks/task_e_68df30f6dc78832bba877d3f866799dd