### PR TITLE
ci: split metrics workflows per target

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -1,186 +1,22 @@
-name: Render metrics for selected repos
+name: Render metrics for selected targets
 
 on:
   schedule:
-    - cron: "19 3 * * *" 
+    - cron: "19 3 * * *"
   workflow_dispatch:
 
 jobs:
-  render:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+  masterror:
+    uses: ./.github/workflows/render-masterror.yml
+    secrets:
+      CLASSIC: ${{ secrets.CLASSIC }}
 
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        target:
-          - { owner: "RAprogramm", repo: "masterror",           filename: "metrics/masterror.svg" }
-          - { owner: "RAprogramm", repo: "telegram-webapp-sdk", filename: "metrics/telegram-webapp-sdk.svg" }
+  profile:
+    uses: ./.github/workflows/render-profile.yml
+    secrets:
+      CLASSIC: ${{ secrets.CLASSIC }}
 
-    env:
-      TZ: Asia/Ho_Chi_Minh
-      BRANCH_NAME: ci/metrics-refresh
-
-    steps:
-      - name: Checkout renderer
-        uses: actions/checkout@v5
-
-      # 1) Рендерим repository template ДЛЯ КАЖДОГО репозитория из матрицы
-      - name: Generate repository metrics SVG
-        uses: lowlighter/metrics@latest
-        with:
-          token: ${{ secrets.CLASSIC }}            # fine-grained PAT с RW на целевые репо
-          user:  ${{ matrix.target.owner }}            # владелец
-          repo:  ${{ matrix.target.repo }}             # сам репозиторий
-          template: repository                          # <— ВАЖНО: используем репозитория-шаблон
-          filename: repo.tmp.svg                        # генерим во временный файл в $GITHUB_WORKSPACE
-          base: "header, activity, community, metadata" 
-          config_timezone: ${{ env.TZ }}
-          cache: 12h
-          # Плагины, которые адекватно смотрятся для repo template
-          plugin_lines: yes                             # строки кода (суммарно, без клоунских графиков)
-          plugin_followup: yes                          # активность по issues/PR
-          plugin_followup_sections: repositories, user  # вклад в репо и от пользователя
-          plugin_projects: no                           # можно включить и указать project board, если есть
-          plugin_licenses: yes
-          plugin_contributors: yes
-          # Можно добавить ещё: plugin_licenses, plugin_contributors и т.д., но не перегружай
-
-      - name: Verify generated artifact
-        run: |
-          set -eu
-          test -f "$GITHUB_WORKSPACE/repo.tmp.svg"
-          echo "Generated: $GITHUB_WORKSPACE/repo.tmp.svg"
-
-      - name: Move artifact into repository workspace
-        run: |
-          set -euo pipefail
-          TARGET_PATH="${{ matrix.target.filename }}"
-          mkdir -p "$(dirname "${TARGET_PATH}")"
-          mv "$GITHUB_WORKSPACE/repo.tmp.svg" "${TARGET_PATH}"
-          echo "Stored metrics at ${TARGET_PATH}"
-
-      - name: Commit metrics update
-        id: update
-        run: |
-          set -euo pipefail
-
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config pull.rebase true
-
-          DEFAULT_REF="$(git symbolic-ref --quiet --short HEAD || true)"
-          if [ -z "${DEFAULT_REF}" ]; then
-            DEFAULT_REF="main"
-          fi
-
-          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
-            git fetch --no-tags --prune --depth=1 origin \
-              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
-            git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
-          else
-            git fetch --no-tags --prune --depth=1 origin \
-              "+refs/heads/${DEFAULT_REF}:refs/remotes/origin/${DEFAULT_REF}" || true
-            git checkout -B "${BRANCH_NAME}" "origin/${DEFAULT_REF}" || git checkout -B "${BRANCH_NAME}" "${DEFAULT_REF}"
-          fi
-
-          UPSTREAM_BEFORE="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
-
-          git add "${{ matrix.target.filename }}"
-
-          if git diff --cached --quiet; then
-            echo "No changes to commit."
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git commit -m "chore(metrics): refresh ${{ matrix.target.repo }}"
-
-          PUSHED=false
-          for ATTEMPT in 1 2 3; do
-            if git push origin "${BRANCH_NAME}"; then
-              echo "Push attempt ${ATTEMPT} succeeded with fast-forward update."
-              PUSHED=true
-              echo "pushed=true" >> "$GITHUB_OUTPUT"
-              break
-            fi
-
-            echo "Fast-forward push attempt ${ATTEMPT} failed, verifying remote state before force push..." >&2
-
-            git fetch --no-tags --prune --depth=1 origin \
-              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" || true
-
-            REMOTE_AFTER="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
-
-            if [ -n "${UPSTREAM_BEFORE}" ] && [ "${REMOTE_AFTER}" != "${UPSTREAM_BEFORE}" ]; then
-              echo "Remote branch advanced to ${REMOTE_AFTER}; retrying without force push." >&2
-              continue
-            fi
-
-            if [ -z "${UPSTREAM_BEFORE}" ] && [ -n "${REMOTE_AFTER}" ]; then
-              echo "Remote branch ${BRANCH_NAME} appeared at ${REMOTE_AFTER}; retrying without force push." >&2
-              continue
-            fi
-
-            if [ -n "${UPSTREAM_BEFORE}" ]; then
-              FORCE_ARGS=("--force-with-lease=refs/heads/${BRANCH_NAME}:${UPSTREAM_BEFORE}")
-            else
-              FORCE_ARGS=("--force-with-lease")
-            fi
-
-            if git push "${FORCE_ARGS[@]}" origin "${BRANCH_NAME}"; then
-              echo "Push attempt ${ATTEMPT} succeeded with force-with-lease."
-              PUSHED=true
-              echo "pushed=true" >> "$GITHUB_OUTPUT"
-              break
-            fi
-
-            echo "Force push attempt ${ATTEMPT} failed, refreshing branch and retrying..." >&2
-          done
-
-          if [ "${PUSHED}" != true ]; then
-            echo "Unable to push metrics update after multiple attempts." >&2
-            exit 1
-          fi
-
-          DEFAULT_BASE="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##' || true)"
-          if [ -z "${DEFAULT_BASE}" ]; then DEFAULT_BASE="${DEFAULT_REF}"; fi
-          echo "default_base=${DEFAULT_BASE}" >> "$GITHUB_OUTPUT"
-
-      # 3) Создаём PR через gh CLI, если его ещё нет. Без ребейсов и лишних манипуляций веткой
-      - name: Open PR (idempotent)
-        if: steps.update.outputs.pushed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.CLASSIC }}
-        run: |
-          set -eu
-          REPO="${{ github.repository }}"
-          BASE="${{ steps.update.outputs.default_base }}"
-          HEAD="${BRANCH_NAME}"
-
-          # Если PR уже открыт от этой ветки — ок
-          EXISTING="$(gh pr list -R "$REPO" --head "$HEAD" --state open --json number --jq '.[0].number' || true)"
-          if [ -n "$EXISTING" ]; then
-            echo "PR #$EXISTING already open for $REPO:$HEAD -> $BASE"
-            exit 0
-          fi
-
-          LABEL_ARGS=()
-          for LABEL in ci metrics; do
-            if gh label view "$LABEL" -R "$REPO" >/dev/null 2>&1 || \
-               gh label create "$LABEL" -R "$REPO" --description "Infrastructure automation" >/dev/null 2>&1; then
-              LABEL_ARGS+=("--label" "$LABEL")
-            else
-              echo "Warning: unable to ensure label '$LABEL' on $REPO, skipping" >&2
-            fi
-          done
-
-          gh pr create -R "$REPO" \
-            --head "$HEAD" \
-            --base "$BASE" \
-            --title "chore(metrics): refresh" \
-            --body  "Auto-generated metrics update" \
-            "${LABEL_ARGS[@]}"
+  telegram_webapp_sdk:
+    uses: ./.github/workflows/render-telegram-webapp-sdk.yml
+    secrets:
+      CLASSIC: ${{ secrets.CLASSIC }}

--- a/.github/workflows/render-masterror.yml
+++ b/.github/workflows/render-masterror.yml
@@ -1,0 +1,178 @@
+name: Render metrics for masterror repository
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      CLASSIC:
+        required: true
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      TZ: Asia/Ho_Chi_Minh
+      BRANCH_NAME: ci/metrics-refresh
+      TARGET_OWNER: RAprogramm
+      TARGET_REPO: masterror
+      TARGET_PATH: metrics/masterror.svg
+      TEMP_ARTIFACT: repo.tmp.svg
+
+    steps:
+      - name: Checkout renderer
+        uses: actions/checkout@v5
+
+      - name: Generate repository metrics SVG
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.CLASSIC }}
+          user:  ${{ env.TARGET_OWNER }}
+          repo:  ${{ env.TARGET_REPO }}
+          template: repository
+          filename: ${{ env.TEMP_ARTIFACT }}
+          base: "header, activity, community, metadata"
+          config_timezone: ${{ env.TZ }}
+          cache: 12h
+          plugin_lines: yes
+          plugin_followup: yes
+          plugin_followup_sections: repositories, user
+          plugin_projects: no
+          plugin_licenses: yes
+          plugin_contributors: yes
+
+      - name: Verify generated artifact
+        run: |
+          set -eu
+          test -f "$GITHUB_WORKSPACE/${TEMP_ARTIFACT}"
+          echo "Generated: $GITHUB_WORKSPACE/${TEMP_ARTIFACT}"
+
+      - name: Move artifact into repository workspace
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${TARGET_PATH}")"
+          mv "$GITHUB_WORKSPACE/${TEMP_ARTIFACT}" "${TARGET_PATH}"
+          echo "Stored metrics at ${TARGET_PATH}"
+
+      - name: Commit metrics update
+        id: update
+        run: |
+          set -euo pipefail
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config pull.rebase true
+
+          DEFAULT_REF="$(git symbolic-ref --quiet --short HEAD || true)"
+          if [ -z "${DEFAULT_REF}" ]; then
+            DEFAULT_REF="main"
+          fi
+
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+            git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
+          else
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${DEFAULT_REF}:refs/remotes/origin/${DEFAULT_REF}" || true
+            git checkout -B "${BRANCH_NAME}" "origin/${DEFAULT_REF}" || git checkout -B "${BRANCH_NAME}" "${DEFAULT_REF}"
+          fi
+
+          UPSTREAM_BEFORE="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
+
+          git add "${TARGET_PATH}"
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore(metrics): refresh ${TARGET_REPO}"
+
+          PUSHED=false
+          for ATTEMPT in 1 2 3; do
+            if git push origin "${BRANCH_NAME}"; then
+              echo "Push attempt ${ATTEMPT} succeeded with fast-forward update."
+              PUSHED=true
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            echo "Fast-forward push attempt ${ATTEMPT} failed, verifying remote state before force push..." >&2
+
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" || true
+
+            REMOTE_AFTER="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
+
+            if [ -n "${UPSTREAM_BEFORE}" ] && [ "${REMOTE_AFTER}" != "${UPSTREAM_BEFORE}" ]; then
+              echo "Remote branch advanced to ${REMOTE_AFTER}; retrying without force push." >&2
+              continue
+            fi
+
+            if [ -z "${UPSTREAM_BEFORE}" ] && [ -n "${REMOTE_AFTER}" ]; then
+              echo "Remote branch ${BRANCH_NAME} appeared at ${REMOTE_AFTER}; retrying without force push." >&2
+              continue
+            fi
+
+            if [ -n "${UPSTREAM_BEFORE}" ]; then
+              FORCE_ARGS=("--force-with-lease=refs/heads/${BRANCH_NAME}:${UPSTREAM_BEFORE}")
+            else
+              FORCE_ARGS=("--force-with-lease")
+            fi
+
+            if git push "${FORCE_ARGS[@]}" origin "${BRANCH_NAME}"; then
+              echo "Push attempt ${ATTEMPT} succeeded with force-with-lease."
+              PUSHED=true
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            echo "Force push attempt ${ATTEMPT} failed, refreshing branch and retrying..." >&2
+          done
+
+          if [ "${PUSHED}" != true ]; then
+            echo "Unable to push metrics update after multiple attempts." >&2
+            exit 1
+          fi
+
+          DEFAULT_BASE="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##' || true)"
+          if [ -z "${DEFAULT_BASE}" ]; then DEFAULT_BASE="${DEFAULT_REF}"; fi
+          echo "default_base=${DEFAULT_BASE}" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR (idempotent)
+        if: steps.update.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CLASSIC }}
+        run: |
+          set -eu
+          REPO="${{ github.repository }}"
+          BASE="${{ steps.update.outputs.default_base }}"
+          HEAD="${BRANCH_NAME}"
+
+          EXISTING="$(gh pr list -R "$REPO" --head "$HEAD" --state open --json number --jq '.[0].number' || true)"
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already open for $REPO:$HEAD -> $BASE"
+            exit 0
+          fi
+
+          LABEL_ARGS=()
+          for LABEL in ci metrics; do
+            if gh label view "$LABEL" -R "$REPO" >/dev/null 2>&1 || \
+               gh label create "$LABEL" -R "$REPO" --description "Infrastructure automation" >/dev/null 2>&1; then
+              LABEL_ARGS+=("--label" "$LABEL")
+            else
+              echo "Warning: unable to ensure label '$LABEL' on $REPO, skipping" >&2
+            fi
+          done
+
+          gh pr create -R "$REPO" \
+            --head "$HEAD" \
+            --base "$BASE" \
+            --title "chore(metrics): refresh" \
+            --body  "Auto-generated metrics update" \
+            "${LABEL_ARGS[@]}"

--- a/.github/workflows/render-profile.yml
+++ b/.github/workflows/render-profile.yml
@@ -1,0 +1,180 @@
+name: Render metrics for RAprogramm profile
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      CLASSIC:
+        required: true
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      TZ: Asia/Ho_Chi_Minh
+      BRANCH_NAME: ci/metrics-refresh
+      TARGET_USER: RAprogramm
+      TARGET_PATH: metrics/profile.svg
+      TEMP_ARTIFACT: profile.tmp.svg
+
+    steps:
+      - name: Checkout renderer
+        uses: actions/checkout@v5
+
+      - name: Generate profile metrics SVG
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.CLASSIC }}
+          user:  ${{ env.TARGET_USER }}
+          template: classic
+          filename: ${{ env.TEMP_ARTIFACT }}
+          base: "header, activity, community, repositories"
+          config_timezone: ${{ env.TZ }}
+          cache: 12h
+          plugin_isocalendar: yes
+          plugin_isocalendar_duration: full-year
+          plugin_habits: yes
+          plugin_habits_charts: true
+          plugin_habits_days: 14
+          plugin_habits_facts: true
+          plugin_habits_from: 200
+          plugin_languages: yes
+          plugin_languages_sections: most-used
+          plugin_languages_details: bytes-size, percentage
+
+      - name: Verify generated artifact
+        run: |
+          set -eu
+          test -f "$GITHUB_WORKSPACE/${TEMP_ARTIFACT}"
+          echo "Generated: $GITHUB_WORKSPACE/${TEMP_ARTIFACT}"
+
+      - name: Move artifact into repository workspace
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${TARGET_PATH}")"
+          mv "$GITHUB_WORKSPACE/${TEMP_ARTIFACT}" "${TARGET_PATH}"
+          echo "Stored metrics at ${TARGET_PATH}"
+
+      - name: Commit metrics update
+        id: update
+        run: |
+          set -euo pipefail
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config pull.rebase true
+
+          DEFAULT_REF="$(git symbolic-ref --quiet --short HEAD || true)"
+          if [ -z "${DEFAULT_REF}" ]; then
+            DEFAULT_REF="main"
+          fi
+
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+            git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
+          else
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${DEFAULT_REF}:refs/remotes/origin/${DEFAULT_REF}" || true
+            git checkout -B "${BRANCH_NAME}" "origin/${DEFAULT_REF}" || git checkout -B "${BRANCH_NAME}" "${DEFAULT_REF}"
+          fi
+
+          UPSTREAM_BEFORE="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
+
+          git add "${TARGET_PATH}"
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore(metrics): refresh profile"
+
+          PUSHED=false
+          for ATTEMPT in 1 2 3; do
+            if git push origin "${BRANCH_NAME}"; then
+              echo "Push attempt ${ATTEMPT} succeeded with fast-forward update."
+              PUSHED=true
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            echo "Fast-forward push attempt ${ATTEMPT} failed, verifying remote state before force push..." >&2
+
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" || true
+
+            REMOTE_AFTER="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
+
+            if [ -n "${UPSTREAM_BEFORE}" ] && [ "${REMOTE_AFTER}" != "${UPSTREAM_BEFORE}" ]; then
+              echo "Remote branch advanced to ${REMOTE_AFTER}; retrying without force push." >&2
+              continue
+            fi
+
+            if [ -z "${UPSTREAM_BEFORE}" ] && [ -n "${REMOTE_AFTER}" ]; then
+              echo "Remote branch ${BRANCH_NAME} appeared at ${REMOTE_AFTER}; retrying without force push." >&2
+              continue
+            fi
+
+            if [ -n "${UPSTREAM_BEFORE}" ]; then
+              FORCE_ARGS=("--force-with-lease=refs/heads/${BRANCH_NAME}:${UPSTREAM_BEFORE}")
+            else
+              FORCE_ARGS=("--force-with-lease")
+            fi
+
+            if git push "${FORCE_ARGS[@]}" origin "${BRANCH_NAME}"; then
+              echo "Push attempt ${ATTEMPT} succeeded with force-with-lease."
+              PUSHED=true
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            echo "Force push attempt ${ATTEMPT} failed, refreshing branch and retrying..." >&2
+          done
+
+          if [ "${PUSHED}" != true ]; then
+            echo "Unable to push metrics update after multiple attempts." >&2
+            exit 1
+          fi
+
+          DEFAULT_BASE="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##' || true)"
+          if [ -z "${DEFAULT_BASE}" ]; then DEFAULT_BASE="${DEFAULT_REF}"; fi
+          echo "default_base=${DEFAULT_BASE}" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR (idempotent)
+        if: steps.update.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CLASSIC }}
+        run: |
+          set -eu
+          REPO="${{ github.repository }}"
+          BASE="${{ steps.update.outputs.default_base }}"
+          HEAD="${BRANCH_NAME}"
+
+          EXISTING="$(gh pr list -R "$REPO" --head "$HEAD" --state open --json number --jq '.[0].number' || true)"
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already open for $REPO:$HEAD -> $BASE"
+            exit 0
+          fi
+
+          LABEL_ARGS=()
+          for LABEL in ci metrics; do
+            if gh label view "$LABEL" -R "$REPO" >/dev/null 2>&1 || \
+               gh label create "$LABEL" -R "$REPO" --description "Infrastructure automation" >/dev/null 2>&1; then
+              LABEL_ARGS+=("--label" "$LABEL")
+            else
+              echo "Warning: unable to ensure label '$LABEL' on $REPO, skipping" >&2
+            fi
+          done
+
+          gh pr create -R "$REPO" \
+            --head "$HEAD" \
+            --base "$BASE" \
+            --title "chore(metrics): refresh" \
+            --body  "Auto-generated metrics update" \
+            "${LABEL_ARGS[@]}"

--- a/.github/workflows/render-telegram-webapp-sdk.yml
+++ b/.github/workflows/render-telegram-webapp-sdk.yml
@@ -1,0 +1,178 @@
+name: Render metrics for telegram-webapp-sdk repository
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      CLASSIC:
+        required: true
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      TZ: Asia/Ho_Chi_Minh
+      BRANCH_NAME: ci/metrics-refresh
+      TARGET_OWNER: RAprogramm
+      TARGET_REPO: telegram-webapp-sdk
+      TARGET_PATH: metrics/telegram-webapp-sdk.svg
+      TEMP_ARTIFACT: repo.tmp.svg
+
+    steps:
+      - name: Checkout renderer
+        uses: actions/checkout@v5
+
+      - name: Generate repository metrics SVG
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.CLASSIC }}
+          user:  ${{ env.TARGET_OWNER }}
+          repo:  ${{ env.TARGET_REPO }}
+          template: repository
+          filename: ${{ env.TEMP_ARTIFACT }}
+          base: "header, activity, community, metadata"
+          config_timezone: ${{ env.TZ }}
+          cache: 12h
+          plugin_lines: yes
+          plugin_followup: yes
+          plugin_followup_sections: repositories, user
+          plugin_projects: no
+          plugin_licenses: yes
+          plugin_contributors: yes
+
+      - name: Verify generated artifact
+        run: |
+          set -eu
+          test -f "$GITHUB_WORKSPACE/${TEMP_ARTIFACT}"
+          echo "Generated: $GITHUB_WORKSPACE/${TEMP_ARTIFACT}"
+
+      - name: Move artifact into repository workspace
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${TARGET_PATH}")"
+          mv "$GITHUB_WORKSPACE/${TEMP_ARTIFACT}" "${TARGET_PATH}"
+          echo "Stored metrics at ${TARGET_PATH}"
+
+      - name: Commit metrics update
+        id: update
+        run: |
+          set -euo pipefail
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config pull.rebase true
+
+          DEFAULT_REF="$(git symbolic-ref --quiet --short HEAD || true)"
+          if [ -z "${DEFAULT_REF}" ]; then
+            DEFAULT_REF="main"
+          fi
+
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+            git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
+          else
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${DEFAULT_REF}:refs/remotes/origin/${DEFAULT_REF}" || true
+            git checkout -B "${BRANCH_NAME}" "origin/${DEFAULT_REF}" || git checkout -B "${BRANCH_NAME}" "${DEFAULT_REF}"
+          fi
+
+          UPSTREAM_BEFORE="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
+
+          git add "${TARGET_PATH}"
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore(metrics): refresh ${TARGET_REPO}"
+
+          PUSHED=false
+          for ATTEMPT in 1 2 3; do
+            if git push origin "${BRANCH_NAME}"; then
+              echo "Push attempt ${ATTEMPT} succeeded with fast-forward update."
+              PUSHED=true
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            echo "Fast-forward push attempt ${ATTEMPT} failed, verifying remote state before force push..." >&2
+
+            git fetch --no-tags --prune --depth=1 origin \
+              "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}" || true
+
+            REMOTE_AFTER="$(git rev-parse --verify "origin/${BRANCH_NAME}" 2>/dev/null || true)"
+
+            if [ -n "${UPSTREAM_BEFORE}" ] && [ "${REMOTE_AFTER}" != "${UPSTREAM_BEFORE}" ]; then
+              echo "Remote branch advanced to ${REMOTE_AFTER}; retrying without force push." >&2
+              continue
+            fi
+
+            if [ -z "${UPSTREAM_BEFORE}" ] && [ -n "${REMOTE_AFTER}" ]; then
+              echo "Remote branch ${BRANCH_NAME} appeared at ${REMOTE_AFTER}; retrying without force push." >&2
+              continue
+            fi
+
+            if [ -n "${UPSTREAM_BEFORE}" ]; then
+              FORCE_ARGS=("--force-with-lease=refs/heads/${BRANCH_NAME}:${UPSTREAM_BEFORE}")
+            else
+              FORCE_ARGS=("--force-with-lease")
+            fi
+
+            if git push "${FORCE_ARGS[@]}" origin "${BRANCH_NAME}"; then
+              echo "Push attempt ${ATTEMPT} succeeded with force-with-lease."
+              PUSHED=true
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            echo "Force push attempt ${ATTEMPT} failed, refreshing branch and retrying..." >&2
+          done
+
+          if [ "${PUSHED}" != true ]; then
+            echo "Unable to push metrics update after multiple attempts." >&2
+            exit 1
+          fi
+
+          DEFAULT_BASE="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##' || true)"
+          if [ -z "${DEFAULT_BASE}" ]; then DEFAULT_BASE="${DEFAULT_REF}"; fi
+          echo "default_base=${DEFAULT_BASE}" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR (idempotent)
+        if: steps.update.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CLASSIC }}
+        run: |
+          set -eu
+          REPO="${{ github.repository }}"
+          BASE="${{ steps.update.outputs.default_base }}"
+          HEAD="${BRANCH_NAME}"
+
+          EXISTING="$(gh pr list -R "$REPO" --head "$HEAD" --state open --json number --jq '.[0].number' || true)"
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already open for $REPO:$HEAD -> $BASE"
+            exit 0
+          fi
+
+          LABEL_ARGS=()
+          for LABEL in ci metrics; do
+            if gh label view "$LABEL" -R "$REPO" >/dev/null 2>&1 || \
+               gh label create "$LABEL" -R "$REPO" --description "Infrastructure automation" >/dev/null 2>&1; then
+              LABEL_ARGS+=("--label" "$LABEL")
+            else
+              echo "Warning: unable to ensure label '$LABEL' on $REPO, skipping" >&2
+            fi
+          done
+
+          gh pr create -R "$REPO" \
+            --head "$HEAD" \
+            --base "$BASE" \
+            --title "chore(metrics): refresh" \
+            --body  "Auto-generated metrics update" \
+            "${LABEL_ARGS[@]}"


### PR DESCRIPTION
## Summary
- add dedicated workflows for rendering masterror, RAprogramm profile, and telegram-webapp-sdk metrics
- update the render-all workflow to orchestrate the individual renderers and pass shared secrets

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df3f01451c832ba4b9d8a11b121f49