### PR TITLE
chore(ci): pin metrics action to v3.34

### DIFF
--- a/.github/workflows/render-masterror.yml
+++ b/.github/workflows/render-masterror.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Checkout renderer
         uses: actions/checkout@v5
 
-      - name: Generate repository metrics SVG
-        uses: lowlighter/metrics@latest
+      - name: Metrics embed
+        uses: lowlighter/metrics@v3.34
         with:
           token: ${{ secrets.CLASSIC }}
           user:  ${{ env.TARGET_OWNER }}

--- a/.github/workflows/render-profile.yml
+++ b/.github/workflows/render-profile.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Checkout renderer
         uses: actions/checkout@v5
 
-      - name: Generate profile metrics SVG
-        uses: lowlighter/metrics@latest
+      - name: Metrics embed
+        uses: lowlighter/metrics@v3.34
         with:
           token: ${{ secrets.CLASSIC }}
           user:  ${{ env.TARGET_USER }}

--- a/.github/workflows/render-telegram-webapp-sdk.yml
+++ b/.github/workflows/render-telegram-webapp-sdk.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Checkout renderer
         uses: actions/checkout@v5
 
-      - name: Generate repository metrics SVG
-        uses: lowlighter/metrics@latest
+      - name: Metrics embed
+        uses: lowlighter/metrics@v3.34
         with:
           token: ${{ secrets.CLASSIC }}
           user:  ${{ env.TARGET_OWNER }}


### PR DESCRIPTION
## Summary
- switch metrics generation workflows to the Marketplace "Metrics embed" step name
- pin lowlighter/metrics action usage to v3.34 for reproducible renders

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df40d35358832bbd2afcfd5a5f0708